### PR TITLE
Make popup functions into macros

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use crate::{
-    accessors,
+    accessors, any_popup_visible,
     cmdbar::CommandBar,
     components::{
         event_pump, CommandBlocking, CommandInfo, CommitComponent,
@@ -9,9 +9,11 @@ use crate::{
         RenameBranchComponent, ResetComponent, SelectBranchComponent,
         StashMsgComponent, TagCommitComponent,
     },
+    draw_popups,
     input::{Input, InputEvent, InputState},
     keys::{KeyConfig, SharedKeyConfig},
     queue::{Action, InternalEvent, NeedsUpdate, Queue},
+    setup_popups,
     strings::{self, order},
     tabs::{Revlog, StashList, Stashing, Status},
     ui::style::{SharedTheme, Theme},
@@ -358,6 +360,23 @@ impl App {
         ]
     );
 
+    setup_popups!(
+        self,
+        [
+            help,
+            reset,
+            msg,
+            stashmsg_popup,
+            inspect_commit_popup,
+            external_editor_popup,
+            tag_commit_popup,
+            create_branch_popup,
+            push_popup,
+            select_branch_popup,
+            rename_branch_popup
+        ]
+    );
+
     fn check_quit_key(&mut self, ev: Event) -> bool {
         if let Event::Key(e) = ev {
             if e == self.key_config.exit {
@@ -584,53 +603,6 @@ impl App {
         );
 
         res
-    }
-
-    //TODO: make this automatic, i keep forgetting to add popups here
-    fn any_popup_visible(&self) -> bool {
-        self.commit.is_visible()
-            || self.help.is_visible()
-            || self.reset.is_visible()
-            || self.msg.is_visible()
-            || self.stashmsg_popup.is_visible()
-            || self.inspect_commit_popup.is_visible()
-            || self.external_editor_popup.is_visible()
-            || self.tag_commit_popup.is_visible()
-            || self.create_branch_popup.is_visible()
-            || self.push_popup.is_visible()
-            || self.select_branch_popup.is_visible()
-            || self.rename_branch_popup.is_visible()
-    }
-
-    fn draw_popups<B: Backend>(
-        &self,
-        f: &mut Frame<B>,
-    ) -> Result<()> {
-        let size = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(
-                [
-                    Constraint::Min(1),
-                    Constraint::Length(self.cmdbar.borrow().height()),
-                ]
-                .as_ref(),
-            )
-            .split(f.size())[0];
-
-        self.commit.draw(f, size)?;
-        self.stashmsg_popup.draw(f, size)?;
-        self.help.draw(f, size)?;
-        self.inspect_commit_popup.draw(f, size)?;
-        self.external_editor_popup.draw(f, size)?;
-        self.tag_commit_popup.draw(f, size)?;
-        self.select_branch_popup.draw(f, size)?;
-        self.create_branch_popup.draw(f, size)?;
-        self.rename_branch_popup.draw(f, size)?;
-        self.push_popup.draw(f, size)?;
-        self.reset.draw(f, size)?;
-        self.msg.draw(f, size)?;
-
-        Ok(())
     }
 
     //TODO: make this dynamic

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -74,6 +74,49 @@ macro_rules! accessors {
     };
 }
 
+/// creates a function to determine if any popup is visible
+#[macro_export]
+macro_rules! any_popup_visible {
+    ($self:ident, [$($element:ident),+]) => {
+        fn any_popup_visible(& $self) -> bool{
+            ($($self.$element.is_visible()) || +)
+        }
+    };
+}
+
+/// creates the draw popup function
+#[macro_export]
+macro_rules! draw_popups {
+    ($self:ident, [$($element:ident),+]) => {
+        fn draw_popups<B: Backend>(& $self, mut f: &mut Frame<B>) -> Result<()>{
+            let size = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(
+                [
+                    Constraint::Min(1),
+                    Constraint::Length($self.cmdbar.borrow().height()),
+                ]
+                .as_ref(),
+            )
+            .split(f.size())[0];
+
+            ($($self.$element.draw(&mut f, size)?) , +);
+
+            return Ok(());
+        }
+    };
+}
+
+/// simply calls
+/// any_popup_visible!() and draw_popups!() macros
+#[macro_export]
+macro_rules! setup_popups {
+    ($self:ident, [$($element:ident),+]) => {
+        any_popup_visible!($self, [$($element),+]);
+        draw_popups!($self, [ $($element),+ ]);
+    };
+}
+
 /// returns `true` if event was consumed
 pub fn event_pump(
     ev: Event,


### PR DESCRIPTION
Turns popup functions into macros, so they are easier to implement in the future.