### PR TITLE
Give a better error message for editor env var empty

### DIFF
--- a/src/components/externaleditor.rs
+++ b/src/components/externaleditor.rs
@@ -75,7 +75,7 @@ impl ExternalEditorComponent {
         let mut editor = editor.split_whitespace();
 
         let command = editor.next().ok_or_else(|| {
-            anyhow!("unable to read editor command")
+            anyhow!("Environment config variable for opening an editor is empty, check \"GIT_EDITOR\", \"VISUAL\" and \"EDITOR\" environment variables are not empty.")
         })?;
 
         let mut editor: Vec<&OsStr> =


### PR DESCRIPTION
Gives a better error message if the editor environment variable is empty, the user did not mean to set this as empty, but we should inform them if they did, with a potential solution